### PR TITLE
Fix invalid metadata attribute

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 # roles/hosts/defaults/main.yml
 ---
 
+hosts_playbook_version: "1.0.1"
+
 # If set to true, an entry for `ansible_hostname`, bound to the host's default IPv4 address is added added.
 hosts_add_default_ipv4: true
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -35,4 +35,3 @@ galaxy_info:
   categories:
     - system
 dependencies: []
-version: 1.0.1


### PR DESCRIPTION
@bertvv 

Thank you for this explicit and tidy role, have found little issue when running for the first time

``` bash
ERROR! 'version' is not a valid attribute for a RoleMetadata

The error appears to have been in '/home/----/ansible-hosts/meta/main.yml': line 2, column 1, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

---
galaxy_info:
^ here
```
