### PR TITLE
Allow to configure network interface

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,3 +17,9 @@ hosts_entries: []
 
 # Custom host file snippets to be added
 hosts_file_snippets: []
+
+# IP protocol to use
+ip_protocol: 'ipv4'
+
+# Network interface to use
+network_interface: "{{ansible_default_ipv4.interface}}"

--- a/templates/etc_hosts.j2
+++ b/templates/etc_hosts.j2
@@ -18,8 +18,8 @@ ff02::2  ip6-allrouters
 {% if hosts_add_ansible_managed_hosts %}
 
 # Entries for Ansible managed hosts
-{% for host in groups['all'] if hostvars[host]['ansible_default_ipv4'] is defined %}
-{{ hostvars[host]['ansible_default_ipv4']['address'] }} {{ hostvars[host]['ansible_fqdn'] }} {{ hostvars[host]['ansible_hostname'] }}
+{% for host in groups['all'] if hostvars[host][ansible_network_interface] is defined %}
+{{ hostvars[host][ansible_network_interface][ip_protocol]['address'] }} {{ hostvars[host]['ansible_fqdn'] }} {{ hostvars[host]['ansible_hostname'] }}
 {% endfor %}
 {% endif %}
 {% if hosts_entries|length != 0 %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,3 +3,4 @@
 
 hosts_file: /etc/hosts
 
+ansible_network_interface: "ansible_{{network_interface}}"


### PR DESCRIPTION
@bertvv 

Hi, this let's to configure IP protocol and interface to use.
Default output this is same as 'ansible_default_ipv4'.

P.S. how about introducing CI (travis-ci.org) for this repo ?
