### PR TITLE
Bugfix for hosts_network_interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ None of the variables below are required. When not set, the default setting is a
 | `hosts_entries`                          | []                                   | A list of dicts with custom entries to be added to the hosts file. See below for an example.                      |
 | `hosts_file_snippets`                    | []                                   | A list of files containing host file snippets to be added to the hosts file verbatim.                             |
 | `hosts_ip_protocol`                      | `ipv4`                               | When adding Ansible managed hosts, this specifies the IP protocol (`ipv4` or `ipv6`)                              |
-| `hosts_network_interface`                | `{{ansible_default_ipv4.interface}}` | When adding Ansible managed hosts, this specifies the network interface for which the IP address should be added. |
+| `hosts_network_interface`                | ''                                   | When adding Ansible managed hosts, this specifies the network interface for which the IP address should be added. |
 | `hosts_file_backup`                      | no                                   | If yes, backup of host file is created with timestamp                                                             |
 |                                          |                                      |                                                                                                                   |
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,8 +24,9 @@ hosts_file_snippets: []
 # IP protocol to use
 hosts_ip_protocol: 'ipv4'
 
-# Network interface to use
-hosts_network_interface: "{{ ansible_default_ipv4.interface }}"
+# Network interface to use. If empty, use the default adapter for each host.
+# NOTE: this only works if all nodes in your inventory have an adapter with the same name.
+hosts_network_interface: ''
 
 # Backup of previous host
 host_file_backup: no

--- a/templates/etc_hosts.j2
+++ b/templates/etc_hosts.j2
@@ -19,8 +19,25 @@ ff02::2  ip6-allrouters
 
 # Entries for Ansible managed hosts
 {% for group in hosts_add_ansible_managed_hosts_groups %}
-{% for host in groups[group] if hostvars[host][hosts_ansible_network_interface] is defined %}
-{{ hostvars[host][hosts_ansible_network_interface][hosts_ip_protocol]['address'] }} {{ hostvars[host]['ansible_fqdn'] }} {{ hostvars[host]['ansible_hostname'] }}
+{% for host in groups[group]|sort %}
+{% set address = None -%}
+{% if hosts_network_interface -%}
+    {% set interface_config = hostvars[host]['ansible_' + hosts_network_interface] -%}
+    {% if interface_config is defined -%}
+        {% set protocol_config = interface_config[hosts_ip_protocol] -%}
+        {% if protocol_config is defined -%}
+            {% set address = protocol_config['address']|default(None) -%}
+        {% endif -%}
+    {% endif -%}
+{% else -%}
+    {% set protocol_config = hostvars[host]['ansible_default_' + hosts_ip_protocol] -%}
+    {% if protocol_config is defined -%}
+        {% set address = protocol_config['address']|default(None) -%}
+    {% endif -%}
+{% endif -%}
+{% if address %}
+{{ address }} {{ hostvars[host]['ansible_fqdn'] }} {{ hostvars[host]['ansible_hostname'] }}
+{% endif %}
 {% endfor %}
 {% endfor %}
 {% endif %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,5 +2,3 @@
 ---
 
 hosts_file: /etc/hosts
-
-hosts_ansible_network_interface: "ansible_{{ hosts_network_interface }}"


### PR DESCRIPTION
Previously, the default value for this variable assumed that all hosts have the same default NIC name.

This meant that each node would only have entries for other nodes in the cluster who had a NIC with the same name as its own.

Now, the default is to use the default NIC name for each host.